### PR TITLE
Fix: Update cordova-plugin-add-swift-support version for mabs 7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -104,7 +104,7 @@
     </platform>
 
     <platform name="ios">
-        <dependency id="cordova-plugin-add-swift-support@1.7.2"/>
+        <dependency id="cordova-plugin-add-swift-support@2.0.2"/>
         <js-module src="www/phonegap-nfc.js" name="NFC">
             <runs />
         </js-module>


### PR DESCRIPTION
Update cordova-plugin-add-swift-support version to 2.0.2 because 1.7.2 was causing require cordova module issue on mabs 7(canary)